### PR TITLE
fix: use static calls 

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -109,7 +109,7 @@ export abstract class Fetcher {
         ),
       })
     }
-    const result = await multicall.aggregate(calls.map((call) => [call.address, call.callData]))
+    const result = await multicall.callStatic.aggregate(calls.map((call) => [call.address, call.callData]))
     const owner = factoryContract.interface.decodeFunctionResult(
       factoryContract.interface.getFunction('feeToSetter()'),
       result.returnData[0]
@@ -180,7 +180,7 @@ export abstract class Fetcher {
           [pairIndex]
         ),
       })
-    const result = await multicall.aggregate(calls.map((call) => [call.address, call.callData]))
+    const result = await multicall.callStatic.aggregate(calls.map((call) => [call.address, call.callData]))
     for (let resultIndex = 0; resultIndex < result.returnData.length; resultIndex++) {
       const tokenPairAddress = factoryContract.interface.decodeFunctionResult(
         factoryContract.interface.getFunction('allPairs(uint256)'),


### PR DESCRIPTION
# Summary

The new Multicall2 ABI does not have "view" methods. Static calls are required.

<img width="1102" alt="image" src="https://user-images.githubusercontent.com/1926216/163236919-a066bcaa-3c7d-42a9-b8a5-a3e589f6a1d5.png">
