### PR TITLE
Fix gnosis protocol ExactIn and ExactOut

### DIFF
--- a/src/entities/currency.ts
+++ b/src/entities/currency.ts
@@ -24,8 +24,13 @@ export class Currency {
     'Ether',
     '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
   )
-  public static readonly XDAI: Currency = new Currency(18, 'XDAI', 'xDAI')
-  public static readonly MATIC: Currency = new Currency(18, 'MATIC', 'Matic')
+  public static readonly XDAI: Currency = new Currency(18, 'XDAI', 'xDAI', '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE')
+  public static readonly MATIC: Currency = new Currency(
+    18,
+    'MATIC',
+    'Matic',
+    '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
+  )
 
   private static readonly NATIVE_CURRENCY: { [chainId in ChainId]: Currency } = {
     [ChainId.MAINNET]: Currency.ETHER,

--- a/src/entities/trades/gnosis-protocol/GnosisProtocolTrade.ts
+++ b/src/entities/trades/gnosis-protocol/GnosisProtocolTrade.ts
@@ -14,7 +14,7 @@ import { Fraction } from '../../fractions/fraction'
 import { Percent } from '../../fractions/percent'
 import { Price } from '../../fractions/price'
 import { TokenAmount } from '../../fractions/tokenAmount'
-import { currencyEquals } from '../../token'
+import { currencyEquals, Token } from '../../token'
 import { Trade } from '../interfaces/trade'
 import { RoutablePlatform } from '../routable-platform/routable-platform'
 import { tryGetChainId, wrappedCurrency } from '../utils'
@@ -234,7 +234,7 @@ export class GnosisProtocolTrade extends Trade {
     // Require the chain ID
     invariant(chainId !== undefined && RoutablePlatform.GNOSIS_PROTOCOL.supportsChain(chainId), 'CHAIN_ID')
     const tokenIn = wrappedCurrency(currencyIn, chainId)
-    const tokenOut = wrappedCurrency(currencyAmountOut.currency, chainId)
+    const tokenOut = currencyAmountOut.currency as Token
     const amountOutBN = parseUnits(currencyAmountOut.toSignificant(), tokenOut.decimals)
     invariant(!tokenIn.equals(tokenOut), 'CURRENCY')
 

--- a/src/entities/trades/gnosis-protocol/GnosisProtocolTrade.ts
+++ b/src/entities/trades/gnosis-protocol/GnosisProtocolTrade.ts
@@ -170,7 +170,7 @@ export class GnosisProtocolTrade extends Trade {
     // Require the chain ID
     invariant(chainId !== undefined && RoutablePlatform.GNOSIS_PROTOCOL.supportsChain(chainId), 'CHAIN_ID')
     const tokenIn = wrappedCurrency(currencyAmountIn.currency, chainId)
-    const tokenOut = wrappedCurrency(currencyOut, chainId)
+    const tokenOut = currencyOut as Token
     const amountInBN = parseUnits(currencyAmountIn.toSignificant(), tokenIn.decimals)
     invariant(!tokenIn.equals(tokenOut), 'CURRENCY')
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import JSBI from 'jsbi'
 export { JSBI }
 
+export * from './abis'
 export * from './constants'
 export * from './entities'
 export * from './errors'


### PR DESCRIPTION
# Summary

Need this fix for 981.
This change fixes the output Currency, removing the unnecessary wrapping around it.
