### PR TITLE
fix: Uniswap `executionPrice` property

### DIFF
--- a/src/entities/trades/uniswap/Uniswap/Uniswap.ts
+++ b/src/entities/trades/uniswap/Uniswap/Uniswap.ts
@@ -65,10 +65,10 @@ export class UniswapTrade extends TradeWithSwapTransaction {
       : new TokenAmount(outpuCurrency as Token, outputAmountBN.toBigInt())
 
     const executionPrice = new Price({
-      baseCurrency: inputCurrency,
-      quoteCurrency: outpuCurrency,
-      denominator: inputAmount.raw,
-      numerator: inputAmount.raw,
+      baseCurrency: swapRoute.trade.executionPrice.baseCurrency,
+      quoteCurrency: swapRoute.trade.executionPrice.quoteCurrency,
+      denominator: swapRoute.trade.executionPrice.denominator,
+      numerator: swapRoute.trade.executionPrice.numerator,
     })
 
     const priceImpact = new Percent(swapRoute.trade.priceImpact.numerator, swapRoute.trade.priceImpact.denominator)


### PR DESCRIPTION
# Summary 

Fixes the wrong display of trade execution price

![](https://user-images.githubusercontent.com/1926216/173022235-6e34cafa-3912-41ea-807e-008a4b1f1f54.png)

