### PR TITLE
feat: move to `approveAddress` to `Trade` interface

### DIFF
--- a/src/entities/trades/0x/0xTrade.ts
+++ b/src/entities/trades/0x/0xTrade.ts
@@ -25,9 +25,9 @@ import { decodeStringToPercent, platformsFromSources } from './utils'
  * Does not account for slippage, i.e. trades that front run this trade and move the price.
  */
 export class ZeroXTrade extends TradeWithSwapTransaction {
-  private readonly to: string
-  private readonly callData: string
-  private readonly value: string
+  public readonly to: string
+  public readonly callData: string
+  public readonly value: string
 
   public constructor({
     breakdown,
@@ -57,6 +57,7 @@ export class ZeroXTrade extends TradeWithSwapTransaction {
       priceImpact,
       chainId,
       platform: RoutablePlatform.ZEROX,
+      approveAddress: to,
     })
     this.to = to
     this.callData = callData

--- a/src/entities/trades/curve/CurveTrade.ts
+++ b/src/entities/trades/curve/CurveTrade.ts
@@ -49,10 +49,6 @@ const debugCurveGetQuote = debug('ecoRouter:curve:getQuote')
  */
 export class CurveTrade extends Trade {
   /**
-   * An address the EOA must approve to spend its tokenIn
-   */
-  public readonly approveAddress: string
-  /**
    * The Unsigned transaction
    */
   public readonly transactionRequest: UnsignedTransaction
@@ -100,9 +96,9 @@ export class CurveTrade extends Trade {
       chainId,
       platform: RoutablePlatform.CURVE,
       fee,
+      approveAddress: approveAddress || (transactionRequest.to as string),
     })
     this.transactionRequest = transactionRequest
-    this.approveAddress = approveAddress || (transactionRequest.to as string)
     this.contract = contract
   }
 

--- a/src/entities/trades/gnosis-protocol/GnosisProtocolTrade.ts
+++ b/src/entities/trades/gnosis-protocol/GnosisProtocolTrade.ts
@@ -38,11 +38,6 @@ export class GnosisProtocolTrade extends Trade {
   public order: Order
 
   /**
-   * An address the EOA must approve to spend its tokenIn
-   */
-  public readonly approveAddress: string
-
-  /**
    * Order signature
    */
   private orderSignatureInfo?: {
@@ -87,9 +82,9 @@ export class GnosisProtocolTrade extends Trade {
       priceImpact: new Percent('0'),
       platform: RoutablePlatform.GNOSIS_PROTOCOL,
       fee,
+      approveAddress: GPv2VaultRelayerList[chainId as unknown as keyof typeof GPv2VaultRelayerList].address,
     })
     this.order = order
-    this.approveAddress = GPv2VaultRelayerList[chainId as unknown as keyof typeof GPv2VaultRelayerList].address
     // The fee token and amount are sell token
     this.feeAmount = feeAmount
   }

--- a/src/entities/trades/interfaces/trade.ts
+++ b/src/entities/trades/interfaces/trade.ts
@@ -22,6 +22,7 @@ export interface TradeConstructorParams {
   chainId: ChainId
   platform: RoutablePlatform
   fee?: Percent
+  approveAddress: string
 }
 
 /**
@@ -30,17 +31,44 @@ export interface TradeConstructorParams {
  */
 export abstract class Trade {
   public readonly details: Details
-  public readonly tradeType: TradeType
-  public readonly inputAmount: CurrencyAmount
-  public readonly outputAmount: CurrencyAmount
-  public readonly maximumSlippage: Percent
-  public readonly executionPrice: Price
-  public readonly priceImpact: Percent
-  public readonly chainId: ChainId
-  public readonly platform: RoutablePlatform
-
   /**
-   * The protocol fee
+   * The input amount of the trade.
+   */
+  public readonly tradeType: TradeType
+  /**
+   * The input amount of the trade.
+   */
+  public readonly inputAmount: CurrencyAmount
+  /**
+   * The output amount of the trade.
+   */
+  public readonly outputAmount: CurrencyAmount
+  /**
+   * The maximum slippage allowed in the trade.
+   */
+  public readonly maximumSlippage: Percent
+  /**
+   * The execution price of the trade.
+   */
+  public readonly executionPrice: Price
+  /**
+   * The price impact of the trade, as a percentage.
+   */
+  public readonly priceImpact: Percent
+  /**
+   * The chainId of the trade.
+   */
+  public readonly chainId: ChainId
+  /**
+   * A platform that this trade is executed on.
+   */
+  public readonly platform: RoutablePlatform
+  /**
+   * An address the EOA must approve to spend its tokenIn
+   */
+  public readonly approveAddress: string
+  /**
+   * The trade fee
    */
   public readonly fee: Percent
 
@@ -55,6 +83,7 @@ export abstract class Trade {
     chainId,
     platform,
     fee = new Percent('0'),
+    approveAddress,
   }: TradeConstructorParams) {
     this.details = details
     this.tradeType = type
@@ -66,6 +95,7 @@ export abstract class Trade {
     this.chainId = chainId
     this.platform = platform
     this.fee = fee
+    this.approveAddress = approveAddress
   }
 
   /**

--- a/src/entities/trades/uniswap-v2/UniswapV2.ts
+++ b/src/entities/trades/uniswap-v2/UniswapV2.ts
@@ -83,6 +83,7 @@ export class UniswapV2Trade extends TradeWithSwapTransaction {
       priceImpact: computePriceImpact(route.midPrice, inputAmount, outputAmount),
       chainId: route.chainId,
       platform: route.pairs[0].platform,
+      approveAddress: route.pairs[0].platform.routerAddress[chainId] as string,
     })
   }
 

--- a/src/entities/trades/uniswap/Uniswap/Uniswap.ts
+++ b/src/entities/trades/uniswap/Uniswap/Uniswap.ts
@@ -35,11 +35,6 @@ const debugUniswapTradeGetQuote = debug('ecoRouter:uniswap:getQuote')
  */
 export class UniswapTrade extends TradeWithSwapTransaction {
   /**
-   * An address the EOA must approve to spend its tokenIn
-   */
-  public readonly approveAddress: string
-
-  /**
    * @property The original SwapRoute object from the Routing API
    */
   swapRoute: SwapRoute
@@ -95,10 +90,10 @@ export class UniswapTrade extends TradeWithSwapTransaction {
       executionPrice,
       priceImpact,
       fee: new Percent(JSBI.BigInt(fee), '10000'),
+      // Uniswap V3 Router v2 address
+      approveAddress: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45',
     })
     this.swapRoute = swapRoute
-    // Uniswap V3 Router v2 address
-    this.approveAddress = '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45'
   }
 
   static async getQuote(


### PR DESCRIPTION
# Summary

Moves `approveAddress` from `UniswapTrade`, `CurveTrade`, `GnosisProtocolTrade` to `Trade`.  