### PR TITLE
Fix: Correctly returns swapFee in getUniswapV2PairSwapFee

### DIFF
--- a/src/entities/trades/uniswap-v2/pairs/fees.ts
+++ b/src/entities/trades/uniswap-v2/pairs/fees.ts
@@ -37,7 +37,7 @@ export async function getUniswapV2PairSwapFee({
 
     // Push only the successful call results
     if (success) {
-      const { swapFee } = uniswapPairInterface.decodeFunctionResult('swapFee', returnData)
+      const [swapFee] = uniswapPairInterface.decodeFunctionResult('swapFee', returnData)
       acc[pairAddress.toLowerCase()] = swapFee
     }
 


### PR DESCRIPTION
Fixes #1232(https://github.com/levelkdev/swapr-dapp/issues/1232)

We received all the time default fee (0,25%) as getUniswapV2PairSwapFee returns swapFee as undefined