### PR TITLE
Fix: Change decimal places to 3 for 0x trade

### DIFF
--- a/src/entities/trades/0x/0xTrade.ts
+++ b/src/entities/trades/0x/0xTrade.ts
@@ -118,7 +118,7 @@ export class ZeroXTrade extends TradeWithSwapTransaction {
         }&slippagePercentage=${new Percent(
           maximumSlippage.numerator,
           JSBI.multiply(maximumSlippage.denominator, JSBI.BigInt(100))
-        ).toFixed(2)}`
+        ).toFixed(3)}`
       )
 
       if (!response.ok) throw new Error('response not ok')
@@ -181,7 +181,7 @@ export class ZeroXTrade extends TradeWithSwapTransaction {
         }&slippagePercentage=${new Percent(
           maximumSlippage.numerator,
           JSBI.multiply(maximumSlippage.denominator, JSBI.BigInt(100))
-        ).toFixed(2)}`
+        ).toFixed(3)}`
       )
       if (!response.ok) throw new Error('response not ok')
       const json = (await response.json()) as ApiResponse


### PR DESCRIPTION
Change decimal places to 3 for 0x trade. Before we have a hardcoded slippage of 3%, now it is dynamic and we can have a value equal to 0,1%
Before: when slippage was under 1%, we pass to the API 0 slippage.
![Selection_159](https://user-images.githubusercontent.com/100695408/178921088-2c946ae2-1aa0-4b79-8a4f-59bf72e72cb3.png)

After:
![Selection_160](https://user-images.githubusercontent.com/100695408/178921107-27315a4a-9e55-4d1c-9d97-d1013d467709.png)

