### PR TITLE
Move return, add V1METAUSD_ABI. Fix typo

### DIFF
--- a/src/entities/trades/curve/abi/abi.ts
+++ b/src/entities/trades/curve/abi/abi.ts
@@ -78,7 +78,17 @@ export const CURVE_METABTC_ABI: ContractInterface = [
   poolMethods['view']['fee'],
   poolMethods['view']['get_dy(int128,int128,uint256)'],
   poolMethods['nonpayable']['exchange(int128,int128,uint256,uint256)'],
-  poolMethods['nonpayable']['exchange(int128,int128,int256,int256,address)'],
+  poolMethods['nonpayable']['exchange(int128,int128,uint256,uint256,address)'],
+  poolMethods['nonpayable']['exchange_underlying(int128,int128,uint256,uint256)'],
+  poolMethods['nonpayable']['exchange_underlying(int128,int128,uint256,uint256,address)'],
+]
+
+export const CURVE_V1MEDAUSD_ABI: ContractInterface = [
+  poolMethods['view']['fee'],
+  poolMethods['view']['get_dy(int128,int128,uint256)'],
+  poolMethods['view']['get_dy_underlying(int128,int128,uint256)'],
+  poolMethods['nonpayable']['exchange(int128,int128,uint256,uint256)'],
+  poolMethods['nonpayable']['exchange(int128,int128,uint256,uint256,address)'],
   poolMethods['nonpayable']['exchange_underlying(int128,int128,uint256,uint256)'],
   poolMethods['nonpayable']['exchange_underlying(int128,int128,uint256,uint256,address)'],
 ]
@@ -87,7 +97,7 @@ export const CURVE_POOL_ABI_MAP: Record<string, ContractInterface> = {
   ['metabtc']: CURVE_METABTC_ABI,
   ['metabtcbalances']: CURVE_METABTC_ABI,
   ['metausd']: CURVE_METAUSD_ABI,
-  ['v1metausd']: CURVE_METAUSD_ABI,
+  ['v1metausd']: CURVE_V1MEDAUSD_ABI,
   ['metausd-fraxusdc']: CURVE_METAUSD_ABI,
   ['metausdbalances']: CURVE_METAUSD_ABI,
   ['plain2balances']: CURVE_PLAIN_ABI,

--- a/src/entities/trades/curve/abi/abi.ts
+++ b/src/entities/trades/curve/abi/abi.ts
@@ -61,6 +61,7 @@ export const CURVE_ETHXERC20_256_ABI: ContractInterface = [
 export const CURVE_METAUSD_ABI: ContractInterface = [
   poolMethods['view']['fee'],
   poolMethods['view']['get_dy(int128,int128,uint256)'],
+  poolMethods['view']['get_dy_underlying(int128,int128,uint256)'],
   poolMethods['nonpayable']['exchange(int128,int128,uint256,uint256)'],
   poolMethods['nonpayable']['exchange(int128,int128,int256,int256,address)'],
   poolMethods['nonpayable']['exchange_underlying(int128,int128,uint256,uint256)'],

--- a/src/entities/trades/curve/abi/common.ts
+++ b/src/entities/trades/curve/abi/common.ts
@@ -49,6 +49,17 @@ export const poolMethods = {
       ],
       outputs: [{ type: 'uint256', name: '' }],
     },
+    'get_dy_underlying(int128,int128,uint256)': {
+      stateMutability: 'view',
+      type: 'function',
+      name: 'get_dy_underlying',
+      inputs: [
+        { type: 'int128', name: 'i' },
+        { type: 'int128', name: 'j' },
+        { type: 'uint256', name: 'dx' },
+      ],
+      outputs: [{ type: 'uint256', name: '' }],
+    },
     'get_dy_underlying(uint256,uint256,uint256)': {
       stateMutability: 'view',
       type: 'function',
@@ -88,6 +99,20 @@ export const poolMethods = {
         { type: 'int128', name: 'i' },
         { type: 'int128', name: 'j' },
         { type: 'int256', name: '_dx' },
+        { type: 'int256', name: '_min_dy' },
+        { type: 'address', name: '_receiver' },
+      ],
+      outputs: [{ type: 'uint256', name: '' }],
+      // there was no gas in the  in the metaUSD ABI
+    },
+    'exchange(int128,int128,uint256,uint256,address)': {
+      stateMutability: 'nonpayable',
+      type: 'function',
+      name: 'exchange',
+      inputs: [
+        { type: 'int128', name: 'i' },
+        { type: 'int128', name: 'j' },
+        { type: 'uint256', name: '_dx' },
         { type: 'uint256', name: '_min_dy' },
         { type: 'address', name: '_receiver' },
       ],


### PR DESCRIPTION
- Return statement moved to inner if block. This way we can proceed if the signature is found in the abi methods. Needs rework but it's functional
- add filter to pools, no point in throwing an avoidable error
- Add v1metausd_abi