### PR TITLE
feature / Enable lower slippage for zeroX

### DIFF
--- a/src/entities/trades/0x/0xTrade.ts
+++ b/src/entities/trades/0x/0xTrade.ts
@@ -118,7 +118,7 @@ export class ZeroXTrade extends TradeWithSwapTransaction {
         }&slippagePercentage=${new Percent(
           maximumSlippage.numerator,
           JSBI.multiply(maximumSlippage.denominator, JSBI.BigInt(100))
-        ).toFixed(3)}`
+        ).toFixed(4)}`
       )
 
       if (!response.ok) throw new Error('response not ok')


### PR DESCRIPTION
As we are changing the lowest value of slippage from 0,1% to 0,01%, we need to change the value passed to zeroX API and set rounding to 4 decimal places

Connected with changes in https://github.com/levelkdev/swapr-dapp/pull/1278/files